### PR TITLE
fix: fix mobile github application images

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<img class="logo" src="../static/miew-banner.png" alt="Miew Banner"/>
+<img class="logo" src="https://github.com/wearemiew/.github/raw/main/static/miew-banner.png" alt="Miew Banner"/>
 
 ### We build the future, one commit at a time.
 
@@ -7,11 +7,11 @@ We are a digital product studio that solves complex challenges by developing web
 ---
 
 #### Where to Find Us
-[![Website](../static/Miewton-icons.png)](https://www.miew.pt) 
-[![LinkedIn](../static/Miewton-icons-1.png)](https://www.linkedin.com/company/miew/) 
-[![Instagram](../static/Miewton-icons-2.png)](https://www.instagram.com/wearemiew/) 
-[![Dribbble](../static/Miewton-icons-3.png)](https://dribbble.com/miew) 
-[![Behance](../static/Miewton-icons-4.png)](https://www.behance.net/miew) 
+[![Website](https://github.com/wearemiew/.github/raw/main/static/Miewton-icons.png)](https://www.miew.pt) 
+[![LinkedIn](https://github.com/wearemiew/.github/raw/main/static/Miewton-icons-1.png)](https://www.linkedin.com/company/miew/) 
+[![Instagram](https://github.com/wearemiew/.github/raw/main/static/Miewton-icons-2.png)](https://www.instagram.com/wearemiew/) 
+[![Dribbble](https://github.com/wearemiew/.github/raw/main/static/Miewton-icons-3.png)](https://dribbble.com/miew) 
+[![Behance](https://github.com/wearemiew/.github/raw/main/static/Miewton-icons-4.png)](https://www.behance.net/miew) 
 
 ---
 #### Technologies We Love


### PR DESCRIPTION
This pull request updates the image URLs in the `profile/README.md` file to use absolute paths hosted on GitHub instead of relative paths. This ensures the images are correctly displayed regardless of the context in which the file is viewed.

### Updates to image URLs:

* Updated the banner image URL in `profile/README.md` to use an absolute GitHub-hosted URL instead of a relative path.
* Updated the social media icon URLs in the "Where to Find Us" section of `profile/README.md` to use absolute GitHub-hosted URLs instead of relative paths.